### PR TITLE
Adding Travis CI notifications to Slack.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 sudo: false
 language: java
+notifications:
+   slack: 2018swecapstone:IPDjX0h4Za0ztVoCHZXAoq0q


### PR DESCRIPTION
This should add notifications. Slack string is from [Travis CI integration](https://i.imgur.com/QN7NaUM.png
)