### PR TITLE
Changed editorconfig to use 4 spaces instead of 2.

### DIFF
--- a/frontend/.editorconfig
+++ b/frontend/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
Changed editorconfig to use 4 spaces.

.editorconfig typically overrides whatever formatting your IDE has set (at least is does with JetBrains products).

Any generated code will have to be reformatted by the IDE to conform to this.