### PR TITLE
Removing justify text-align from generated Privacy Policy.

### DIFF
--- a/frontend/src/app/privacy/privacy.component.css
+++ b/frontend/src/app/privacy/privacy.component.css
@@ -2,7 +2,6 @@
     font-size:11pt;
     width:100%;
     margin:0 auto;
-    text-align:justify;
 }
 
 .ppHeader {


### PR DESCRIPTION
### Please give a short summary of what's included in this submission
Wesley noticed some awkward spacing issues caused by the privacy policy using the Justify text alignment. I'm changing it to left-aligned to fix the issue.

[Justified](https://files.slack.com/files-pri/T9325MA2E-F9TT67Y1H/screen_shot_2018-03-21_at_6.20.01_pm.png)

[Fixed - Left Aligned](https://i.imgur.com/fLuyyVj.png)

### Checklist
- [x] The Pull Request title describes the changes I've made
- [x] I've reviewed the **Files changed** tab
- [x] The code in the **Files changed** tab meets our style guides
- [x] New classes and public methods in the **Files changed** tab are documented
- [x] I've added two reviewers for this pull request