### PR TITLE
User registration

### DIFF
--- a/src/main/java/edu/harvard/h2ms/config/SecurityConfig.java
+++ b/src/main/java/edu/harvard/h2ms/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     "/login",
     "/webjars/**",
     "/api/passwords/**",
+    "/registration/**",
 
     // swagger ui
     "/swagger-resources",

--- a/src/main/java/edu/harvard/h2ms/domain/core/User.java
+++ b/src/main/java/edu/harvard/h2ms/domain/core/User.java
@@ -77,7 +77,7 @@ public class User implements UserDetails {
     private Set<Role> roles;
 
     @Column(name = "enabled")
-    private boolean enabled;
+    private boolean enabled = true;
 
     @Column(name = "created_on")
     private Date createdOn;
@@ -88,7 +88,8 @@ public class User implements UserDetails {
     @Column(name = "reset_token")
     private String resetToken;
 
-
+    @Column(name = "verified")
+    private boolean verified;
 
     public User(String firstName, String middleName, String lastName, String email, String password, String type) {
         this.firstName = firstName;
@@ -209,11 +210,20 @@ public class User implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return true;
+        return this.enabled;
     }
-
+    
     public void setEnabled(boolean value) {
     	this.enabled = value;
+    }
+
+    public boolean isVerified() {
+    	return this.enabled;
+    }
+
+
+    public void setVerified(boolean value) {
+    	this.verified = value;
     }
 
     public Date getLastLogin() {

--- a/src/main/java/edu/harvard/h2ms/domain/core/User.java
+++ b/src/main/java/edu/harvard/h2ms/domain/core/User.java
@@ -218,7 +218,7 @@ public class User implements UserDetails {
     }
 
     public boolean isVerified() {
-    	return this.enabled;
+    	return this.verified;
     }
 
 

--- a/src/main/java/edu/harvard/h2ms/seeders/UserSeeder.java
+++ b/src/main/java/edu/harvard/h2ms/seeders/UserSeeder.java
@@ -7,6 +7,9 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -15,8 +18,19 @@ import edu.harvard.h2ms.domain.core.User;
 import edu.harvard.h2ms.repository.UserRepository;
 
 @Component
+@PropertySources({
+	@PropertySource(value = "classpath:application.properties",          ignoreResourceNotFound = true),
+	@PropertySource(value = "classpath:application.properties.override", ignoreResourceNotFound = true)
+})
 public class UserSeeder {
     private UserRepository userRepository;
+    
+	@Value("${application.security.properties.admin.usertype}")
+	private String adminUserType;
+	
+	@Value("${application.security.properties.admin.password}")
+	private String adminPassword;
+	
 
     Set<String> questionKeys = new HashSet<String>();
     
@@ -46,8 +60,8 @@ public class UserSeeder {
                 user.setFirstName(firstName);
                 user.setLastName(lastName);
                 user.setEmail(email);
-                user.setPassword("password");
-                user.setType("Admin");
+                user.setPassword(adminPassword);
+                user.setType(adminUserType);
                 userRepository.save(user);
             }
         }

--- a/src/main/java/edu/harvard/h2ms/web/controller/PasswordController.java
+++ b/src/main/java/edu/harvard/h2ms/web/controller/PasswordController.java
@@ -33,7 +33,7 @@ import edu.harvard.h2ms.service.UserService;
  *
  */
 @RestController
-@RequestMapping(path="/api/passwords")
+@RequestMapping(path= {"/api/passwords", "/registration"})
 @PropertySources({
 	@PropertySource(value = "classpath:application.properties",          ignoreResourceNotFound = true),
 	@PropertySource(value = "classpath:application.properties.override", ignoreResourceNotFound = true)
@@ -132,7 +132,7 @@ public class PasswordController {
 	/**
 	 * Restful API for User registration by email
 	 */
-	@RequestMapping(value = "/registration/email", method = RequestMethod.POST)
+	@RequestMapping(value = "/newuser/email", method = RequestMethod.POST)
 	public ResponseEntity<?> registerUserByEmail(@RequestBody Map<String, String> requestParams) {
 		
 		User user = new User();
@@ -142,7 +142,7 @@ public class PasswordController {
 		user.setPassword("password");
 		String userType = requestParams.get("type");
 		
-		user.setType("Unassigned");
+		user.setType(userType);
 		user.setVerified(false);
 		
 		String token = UUID.randomUUID().toString();
@@ -167,6 +167,23 @@ public class PasswordController {
 		userRepository.save(user);
 		
 		
+		
+		SimpleMailMessage message = new SimpleMailMessage();
+		
+		/** user email address **/
+		message.setTo(user.getEmail());
+		
+		/** uncomment for quick test: **/
+		//message.setTo("my.email.address@gmail.com");
+		
+		message.setSubject("h2msreset token - new user registration");
+		message.setText("please use the password reset token: "+user.getResetToken());
+		
+		// actually send the message
+		emailService.sendEmail(message);
+		
+		// Save user
+		userService.save(user);
 		Map<String,String> entity = new HashMap<>();
 		entity.put("action", "user password reset");
 		

--- a/src/main/java/edu/harvard/h2ms/web/controller/PasswordController.java
+++ b/src/main/java/edu/harvard/h2ms/web/controller/PasswordController.java
@@ -137,18 +137,21 @@ public class PasswordController {
 		
 		User user = new User();
 		user.setFirstName(requestParams.get("firstName"));
+		user.setMiddleName(requestParams.get("middleName"));
 		user.setLastName(requestParams.get("lastName"));
 		user.setEmail(requestParams.get("email"));
-		user.setPassword("password");
-		String userType = requestParams.get("type");
+		user.setPassword(requestParams.get("password"));
 		
-		user.setType(userType);
+		// User created will need verification
 		user.setVerified(false);
+		
+		//TODO: User can set their own type? Probably not a good idea.
+		String userType = requestParams.get("type");
+		user.setType(userType);
 		
 		String token = UUID.randomUUID().toString();
 		user.setResetToken(token);
-		
-		
+				
 		if(userRepository.findByEmail(user.getEmail())!= null) {
 			final String MSG = "user email already taken";
 			log.info(MSG);
@@ -163,10 +166,7 @@ public class PasswordController {
 		
 		//TODO: is there a password policy?
 		
-		
 		userRepository.save(user);
-		
-		
 		
 		SimpleMailMessage message = new SimpleMailMessage();
 		
@@ -186,8 +186,6 @@ public class PasswordController {
 		userService.save(user);
 		Map<String,String> entity = new HashMap<>();
 		entity.put("action", "user password reset");
-		
-		
 		
 		return new ResponseEntity<Object>(entity, HttpStatus.OK);
 	}

--- a/src/main/java/edu/harvard/h2ms/web/controller/PasswordController.java
+++ b/src/main/java/edu/harvard/h2ms/web/controller/PasswordController.java
@@ -131,41 +131,34 @@ public class PasswordController {
 
 	/**
 	 * Restful API for User registration by email
+	 * *****************************************
+	 *   FRONT END DEV: DO NOT ASK FOR PASSWORD - it'll be clobbered
+	 * *****************************************
 	 */
 	@RequestMapping(value = "/newuser/email", method = RequestMethod.POST)
-	public ResponseEntity<?> registerUserByEmail(@RequestBody Map<String, String> requestParams) {
-		
-		User user = new User();
-		user.setFirstName(requestParams.get("firstName"));
-		user.setMiddleName(requestParams.get("middleName"));
-		user.setLastName(requestParams.get("lastName"));
-		user.setEmail(requestParams.get("email"));
-		user.setPassword(requestParams.get("password"));
+	public ResponseEntity<?> registerUserByEmail(@RequestBody User user) {
 		
 		// User created will need verification
 		user.setVerified(false);
 		
-		//TODO: User can set their own type? Probably not a good idea.
-		String userType = requestParams.get("type");
-		user.setType(userType);
-		
 		String token = UUID.randomUUID().toString();
 		user.setResetToken(token);
-				
+		
+		//TODO: user password can't be set
+		user.setPassword(token);
 		if(userRepository.findByEmail(user.getEmail())!= null) {
 			final String MSG = "user email already taken";
 			log.info(MSG);
 			return new ResponseEntity<String>(MSG, HttpStatus.CONFLICT);
 		}
 		
-		if(userType == adminUserType) {
+		if(user.getType() == adminUserType) {
 			final String MSG = "admin user cannot be created using standard email registration";
 			log.info(MSG);
 			return new ResponseEntity<String>(MSG, HttpStatus.FORBIDDEN);
 		}
 		
 		//TODO: is there a password policy?
-		
 		userRepository.save(user);
 		
 		SimpleMailMessage message = new SimpleMailMessage();

--- a/src/main/java/edu/harvard/h2ms/web/controller/PasswordController.java
+++ b/src/main/java/edu/harvard/h2ms/web/controller/PasswordController.java
@@ -8,10 +8,14 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriUtils;
 
 import edu.harvard.h2ms.domain.core.User;
+import edu.harvard.h2ms.repository.UserRepository;
 import edu.harvard.h2ms.service.EmailService;
 import edu.harvard.h2ms.service.UserService;
 
@@ -29,9 +34,15 @@ import edu.harvard.h2ms.service.UserService;
  */
 @RestController
 @RequestMapping(path="/api/passwords")
+@PropertySources({
+	@PropertySource(value = "classpath:application.properties",          ignoreResourceNotFound = true),
+	@PropertySource(value = "classpath:application.properties.override", ignoreResourceNotFound = true)
+})
 public class PasswordController {
 	
 	final Logger log = LoggerFactory.getLogger(PasswordController.class);
+	@Value("${application.security.properties.admin.usertype}")
+	private String adminUserType;
 	
 	@Autowired
 	private UserService userService;
@@ -41,6 +52,9 @@ public class PasswordController {
 	
 	@Autowired
 	public JavaMailSender emailSender;
+	
+	@Autowired
+	private UserRepository userRepository;
 	
 	/**
 	 * Sets the reset parameter
@@ -105,6 +119,7 @@ public class PasswordController {
 		User user = userService.findUserByResetToken(token);
 		if(user != null) {
 			user.setPassword(password);
+			user.setVerified(true);
 			// Save user
 			userService.save(user);
 		} else 
@@ -112,4 +127,53 @@ public class PasswordController {
 		
 		return new ResponseEntity<Object>(entity, HttpStatus.OK);
 	}
+	
+
+	/**
+	 * Restful API for User registration by email
+	 */
+	@RequestMapping(value = "/registration/email", method = RequestMethod.POST)
+	public ResponseEntity<?> registerUserByEmail(@RequestBody Map<String, String> requestParams) {
+		
+		User user = new User();
+		user.setFirstName(requestParams.get("firstName"));
+		user.setLastName(requestParams.get("lastName"));
+		user.setEmail(requestParams.get("email"));
+		user.setPassword("password");
+		String userType = requestParams.get("type");
+		
+		user.setType("Unassigned");
+		user.setVerified(false);
+		
+		String token = UUID.randomUUID().toString();
+		user.setResetToken(token);
+		
+		
+		if(userRepository.findByEmail(user.getEmail())!= null) {
+			final String MSG = "user email already taken";
+			log.info(MSG);
+			return new ResponseEntity<String>(MSG, HttpStatus.CONFLICT);
+		}
+		
+		if(userType == adminUserType) {
+			final String MSG = "admin user cannot be created using standard email registration";
+			log.info(MSG);
+			return new ResponseEntity<String>(MSG, HttpStatus.FORBIDDEN);
+		}
+		
+		//TODO: is there a password policy?
+		
+		
+		userRepository.save(user);
+		
+		
+		Map<String,String> entity = new HashMap<>();
+		entity.put("action", "user password reset");
+		
+		
+		
+		return new ResponseEntity<Object>(entity, HttpStatus.OK);
+	}
+	
+	
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 ## Override the port Tomcat listens on
 server.port=8080
 security.oauth2.resource.filter-order=3
+## overridable admin usertype and password
+application.security.properties.admin.usertype=Admin
+application.security.properties.admin.password=password

--- a/src/test/java/edu/harvard/h2ms/controllers/PasswordControllerTests.java
+++ b/src/test/java/edu/harvard/h2ms/controllers/PasswordControllerTests.java
@@ -1,0 +1,133 @@
+package edu.harvard.h2ms.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import edu.harvard.h2ms.domain.core.User;
+import edu.harvard.h2ms.repository.UserRepository;
+
+@RunWith(SpringRunner.class)
+@WebAppConfiguration
+@SpringBootTest
+public class PasswordControllerTests {
+	
+	private static final Log log = LogFactory.getLog(PasswordControllerTests.class);
+	
+    static final String EMAIL = "jqadams@h2ms.org";
+    static final String FIRSTNAME = "John";
+    static final String MIDDLENAME = "Quincy";
+    static final String LASTNAME = "Adams";
+    static final String TYPE = "Doctor";
+    static final String PASSWORD = "password";
+    static final String NEWPASSWORD = "newpassword";
+    static final String CONTENT_TYPE = "application/json;charset=UTF-8";
+    
+    @Autowired
+    private FilterChainProxy springSecurityFilterChain;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mvc;
+    
+    @Autowired
+    UserRepository userRepository;
+    
+    /**
+     * Setup prior to running unit tests
+     * @throws Exception
+     */
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        this.mvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilter(springSecurityFilterChain)
+                .build();
+
+    }
+    
+    /**
+     * Tests user registration
+     */
+    @Test
+    @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+    public void test_csvExport_EventController_exportEvent() throws Exception {
+    	
+    	ObjectMapper mapper1 = new ObjectMapper();
+    	ObjectNode objectNode1 = mapper1.createObjectNode();
+    	objectNode1.put("firstName",  FIRSTNAME );
+    	objectNode1.put("middleName", MIDDLENAME);
+    	objectNode1.put("lastName",   LASTNAME  );
+    	objectNode1.put("email",      EMAIL     );
+    	objectNode1.put("password",   PASSWORD  );
+    	objectNode1.put("type",       TYPE      );
+    	
+    	log.debug("Test: user info for registration "+objectNode1.toString());
+
+    	 MockHttpServletResponse result = mvc.perform(post(String.format("/registration/newuser/email"))
+    			 .contentType(MediaType.APPLICATION_JSON)
+    			 .content(objectNode1.toString())
+    			 .accept(MediaType.APPLICATION_JSON))
+                 .andExpect(status().isOk())
+                 .andReturn()
+                 .getResponse();
+    			 
+
+        log.debug("Test: user info for registration shintest");
+        log.debug(result.getContentAsString());
+        
+        User registeredUser = userRepository.findByEmail(EMAIL);
+        
+        String resetToken = registeredUser.getResetToken();
+        log.debug("isVerified"+registeredUser.isVerified());
+        
+        // should NOT be verified right after registration
+        assertFalse(registeredUser.isVerified());
+        
+        ObjectMapper mapper2 = new ObjectMapper();
+        ObjectNode objectNode2 = mapper2.createObjectNode();
+        objectNode2.put("token", resetToken);
+        objectNode2.put("password", NEWPASSWORD);
+        
+        
+        // do a password reset
+        MockHttpServletResponse result2 = mvc.perform(post(String.format("/registration/reset/token"))
+   			 .contentType(MediaType.APPLICATION_JSON)
+   			 .content(objectNode2.toString())
+   			 .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse();
+        log.debug("Test: user info for password reset");
+        log.debug(result2.getContentAsString());
+        User verifiedUser = userRepository.findByEmail(EMAIL);
+        log.debug("isverified"+verifiedUser.isVerified());
+        
+        // should be verified after password reset
+        assertTrue(verifiedUser.isVerified());
+        
+    }
+}

--- a/src/test/java/edu/harvard/h2ms/controllers/PasswordControllerTests.java
+++ b/src/test/java/edu/harvard/h2ms/controllers/PasswordControllerTests.java
@@ -36,13 +36,13 @@ public class PasswordControllerTests {
 	
 	private static final Log log = LogFactory.getLog(PasswordControllerTests.class);
 	
-    static final String EMAIL = "jqadams@h2ms.org";
-    static final String FIRSTNAME = "John";
-    static final String MIDDLENAME = "Quincy";
-    static final String LASTNAME = "Adams";
-    static final String TYPE = "Doctor";
-    static final String PASSWORD = "password";
-    static final String NEWPASSWORD = "newpassword";
+    static final String EMAIL        = "jqadams@h2ms.org";
+    static final String FIRSTNAME    = "John";
+    static final String MIDDLENAME   = "Quincy";
+    static final String LASTNAME     = "Adams";
+    static final String TYPE         = "Doctor";
+    static final String PASSWORD     = "password";
+    static final String NEWPASSWORD  = "newpassword";
     static final String CONTENT_TYPE = "application/json;charset=UTF-8";
     
     @Autowired
@@ -74,29 +74,25 @@ public class PasswordControllerTests {
      */
     @Test
     @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-    public void test_csvExport_EventController_exportEvent() throws Exception {
+    public void test_register_passwordController_registerUserByEmail() throws Exception {
     	
     	ObjectMapper mapper1 = new ObjectMapper();
-    	ObjectNode objectNode1 = mapper1.createObjectNode();
-    	objectNode1.put("firstName",  FIRSTNAME );
-    	objectNode1.put("middleName", MIDDLENAME);
-    	objectNode1.put("lastName",   LASTNAME  );
-    	objectNode1.put("email",      EMAIL     );
-    	objectNode1.put("password",   PASSWORD  );
-    	objectNode1.put("type",       TYPE      );
+
     	
-    	log.debug("Test: user info for registration "+objectNode1.toString());
+    	User user = new User(FIRSTNAME, MIDDLENAME, LASTNAME, EMAIL, PASSWORD, TYPE);
+    	
+    	log.debug("Test: user info for registration "+mapper1.writeValueAsString(user));
 
     	 MockHttpServletResponse result = mvc.perform(post(String.format("/registration/newuser/email"))
     			 .contentType(MediaType.APPLICATION_JSON)
-    			 .content(objectNode1.toString())
+    			 .content(mapper1.writeValueAsString(user))
     			 .accept(MediaType.APPLICATION_JSON))
                  .andExpect(status().isOk())
                  .andReturn()
                  .getResponse();
     			 
 
-        log.debug("Test: user info for registration shintest");
+        log.debug("Test: user info for registration");
         log.debug(result.getContentAsString());
         
         User registeredUser = userRepository.findByEmail(EMAIL);
@@ -106,6 +102,8 @@ public class PasswordControllerTests {
         
         // should NOT be verified right after registration
         assertFalse(registeredUser.isVerified());
+        
+        assertEquals(registeredUser.getFirstName(), FIRSTNAME);
         
         ObjectMapper mapper2 = new ObjectMapper();
         ObjectNode objectNode2 = mapper2.createObjectNode();
@@ -128,6 +126,9 @@ public class PasswordControllerTests {
         
         // should be verified after password reset
         assertTrue(verifiedUser.isVerified());
+
+        // should still be the same
+        assertEquals(verifiedUser.getFirstName(), FIRSTNAME);
         
     }
 }


### PR DESCRIPTION
### Please give a short summary of what's included in this submission
Added user registration controller using the email and password reset mechanism.  User can register via email, name, password, and user type.  You can't make admin user (defined in profile) using this mechanism.  

The newly minted user is "unverified" until the user gets the email with token and resets the password.  The registration and this password reset email verification mechanism is unit tested.

### Checklist
- [x] The Pull Request title describes the changes I've made
- [x] I've reviewed the **Files changed** tab
- [x] The code in the **Files changed** tab meets our style guides
- [x] New classes and public methods in the **Files changed** tab are documented
- [x] I've added two reviewers for this pull request