### PR TITLE
Proxy to backend from /api in nginx

### DIFF
--- a/frontend/nginx-custom.conf
+++ b/frontend/nginx-custom.conf
@@ -1,8 +1,19 @@
 server {
-  listen 80;
-  location / {
-    root /usr/share/nginx/html;
-    index index.html index.htm;
-    try_files $uri $uri/ /index.html =404;
-  }
+    listen 80;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html =404;
+    }
+
+    location /api {
+        proxy_pass http://h2ms:8080/api;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Host $http_x_forwarded_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-NginX-Proxy true;
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 ## Override the port Tomcat listens on
+server.contextPath=/api
 server.port=8080
 security.oauth2.resource.filter-order=3
 ## overridable admin usertype and password


### PR DESCRIPTION
### Please give a short summary of what's included in this submission

This makes /api on the frontend nginx container pass through directly to
the backend API.  Prerequisite for this to be in before I enabled SSL certs.


### Checklist
- [X] The Pull Request title describes the changes I've made
- [X] I've reviewed the **Files changed** tab
- [X] The code in the **Files changed** tab meets our style guides
- [X] New classes and public methods in the **Files changed** tab are documented
- [X] I've added two reviewers for this pull request