### PR TITLE
Change the name of the backend image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - db
     command: db:5432
 
-  h2ms:
+  backend:
     image: cscie599/h2ms
     ports:
       # external:internal

--- a/frontend/nginx-custom.conf
+++ b/frontend/nginx-custom.conf
@@ -8,7 +8,7 @@ server {
     }
 
     location /api {
-        proxy_pass http://h2ms:8080/api;
+        proxy_pass http://backend:8080/api;
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
### Please give a short summary of what's included in this submission

My actual server's name is 'h2ms' and this conflicts with the docker
container's name which breaks the proxy forwarding.

### Checklist
- [X] The Pull Request title describes the changes I've made
- [X] I've reviewed the **Files changed** tab
- [X] The code in the **Files changed** tab meets our style guides
- [X] New classes and public methods in the **Files changed** tab are documented
- [X] I've added two reviewers for this pull request
