### PR TITLE
Subscription-specific notification interval (Compliance warning 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ node_modules/
 /bin/
 /out.log
 /test.txt
+/log.txt

--- a/src/main/java/edu/harvard/h2ms/domain/core/Notification.java
+++ b/src/main/java/edu/harvard/h2ms/domain/core/Notification.java
@@ -161,7 +161,7 @@ public class Notification {
     return this.emailNotificationIntervals;
   }
 
-  public void setEmailNotificationInterval(Map<String, Long> emailNotificationIntervals) {
+  public void setEmailNotificationIntervals(Map<String, Long> emailNotificationIntervals) {
     this.emailNotificationIntervals = emailNotificationIntervals;
   }
 

--- a/src/main/java/edu/harvard/h2ms/domain/core/Notification.java
+++ b/src/main/java/edu/harvard/h2ms/domain/core/Notification.java
@@ -42,6 +42,23 @@ public class Notification {
   )
   private Set<User> users = new HashSet<>();
 
+  /**
+   * Keeps track of last notification time for each user email See:
+   * https://stackoverflow.com/questions/19199701/how-to-jpa-mapping-a-hashmap
+   */
+  @ElementCollection(fetch = FetchType.EAGER)
+  @CollectionTable(name = "last_notification")
+  @MapKeyColumn(name = "user_email_col")
+  @Column(name = "last_notified_time_col")
+  private Map<String, Long> emailLastNotifiedTimes;
+
+  /** Keeps track of user intervals (this is simpler than dealing with another Hibernate entity) */
+  @ElementCollection(fetch = FetchType.EAGER)
+  @CollectionTable(name = "notification_interval")
+  @MapKeyColumn(name = "user_email_col")
+  @Column(name = "notification_interval_col")
+  private Map<String, Long> emailNotificationIntervals;
+
   @Column(name = "name")
   private String name;
 
@@ -53,16 +70,6 @@ public class Notification {
 
   @Column(name = "notification_body")
   private String notificationBody;
-
-  /**
-   * Keeps track of last notification time for each user email See:
-   * https://stackoverflow.com/questions/19199701/how-to-jpa-mapping-a-hashmap
-   */
-  @ElementCollection(fetch = FetchType.EAGER)
-  @CollectionTable(name = "last_notification")
-  @MapKeyColumn(name = "user_email_col")
-  @Column(name = "last_notified_time_col")
-  private Map<String, Long> emailLastNotifiedTimes;
 
   // dummy constructor
   public Notification() {
@@ -143,11 +150,23 @@ public class Notification {
   }
 
   public void setEmailLastNotifiedTimes(Map<String, Long> emailLastNotifiedTimes) {
-    this.emailLastNotifiedTimes = emailLastNotifiedTimes;
+    this.emailNotificationIntervals = emailLastNotifiedTimes;
   }
 
   public void setEmailLastNotifiedTime(String email, Long unixtime) {
     this.emailLastNotifiedTimes.put(email, unixtime);
+  }
+
+  public Map<String, Long> getEmailNotificationIntervals() {
+    return this.emailNotificationIntervals;
+  }
+
+  public void setEmailNotificationInterval(Map<String, Long> emailNotificationIntervals) {
+    this.emailNotificationIntervals = emailNotificationIntervals;
+  }
+
+  public void setEmailNotificationInterval(String email, Long unixtime) {
+    this.emailNotificationIntervals.put(email, unixtime);
   }
 
   @Override

--- a/src/main/java/edu/harvard/h2ms/seeders/UserSeeder.java
+++ b/src/main/java/edu/harvard/h2ms/seeders/UserSeeder.java
@@ -2,10 +2,14 @@ package edu.harvard.h2ms.seeders;
 
 import static java.util.Arrays.asList;
 
+import edu.harvard.h2ms.domain.core.Role;
+import edu.harvard.h2ms.domain.core.User;
+import edu.harvard.h2ms.repository.RoleRepository;
+import edu.harvard.h2ms.repository.UserRepository;
+import edu.harvard.h2ms.service.utils.ReportUtils.NotificationFrequency;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
@@ -13,12 +17,6 @@ import org.springframework.context.annotation.PropertySources;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-
-import edu.harvard.h2ms.domain.core.Role;
-import edu.harvard.h2ms.domain.core.User;
-import edu.harvard.h2ms.repository.RoleRepository;
-import edu.harvard.h2ms.repository.UserRepository;
-import edu.harvard.h2ms.service.utils.ReportUtils.NotificationFrequency;
 
 @Component
 @PropertySources({

--- a/src/main/java/edu/harvard/h2ms/service/report/NotificationServiceImpl.java
+++ b/src/main/java/edu/harvard/h2ms/service/report/NotificationServiceImpl.java
@@ -124,12 +124,20 @@ public class NotificationServiceImpl {
     NotificationFrequency notificationFrequency =
         NotificationFrequency.getNotificationFrequency(stringNotificationFrequency);
 
+    // if set, get notification's user interal
+    Long notificationSpecificInterval = notification.getEmailNotificationIntervals().get(userEmail);
+
     // define how long to wait for each notification frequency
     if (notificationFrequency == NotificationFrequency.UNDEFINED) {
       notificationFrequency = NotificationFrequency.DAILY;
     }
 
     long interval = notificationFrequency.seconds;
+
+    // if notfication-specific value is found, use this instead of user default
+    if (notificationSpecificInterval != null) {
+      interval = notificationSpecificInterval.longValue();
+    }
 
     long currentTime = ReportUtils.getUnixTime();
 
@@ -152,6 +160,22 @@ public class NotificationServiceImpl {
   public void subscribeUserNotification(User user, Notification notification) {
 
     notification.addUser(user);
+    log.debug("subscribed:" + notification.getUser());
+    resetEmailLastNotifiedTime(notification, user);
+  }
+
+  /**
+   * Adds user to notification's subscription list, with custom interval
+   *
+   * @param user
+   * @param notification
+   */
+  public void subscribeUserNotification(
+      User user, Notification notification, Long notificationInterval) {
+
+    notification.addUser(user);
+    notification.setEmailNotificationInterval(user.getEmail(), notificationInterval);
+
     log.debug("subscribed:" + notification.getUser());
     resetEmailLastNotifiedTime(notification, user);
   }

--- a/src/main/java/edu/harvard/h2ms/web/controller/NotificationController.java
+++ b/src/main/java/edu/harvard/h2ms/web/controller/NotificationController.java
@@ -5,6 +5,7 @@ import edu.harvard.h2ms.domain.core.User;
 import edu.harvard.h2ms.repository.NotificationRepository;
 import edu.harvard.h2ms.repository.UserRepository;
 import edu.harvard.h2ms.service.report.NotificationServiceImpl;
+import edu.harvard.h2ms.service.utils.ReportUtils.NotificationFrequency;
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -40,6 +41,16 @@ public class NotificationController {
 
     String email = (String) requestParams.get("email");
     String notificationName = (String) requestParams.get("notificationName");
+    String notificationInterval = (String) requestParams.get("notificaitonInterval");
+    log.info("*************shintest:" + notificationInterval);
+    NotificationFrequency notificationFrequency =
+        NotificationFrequency.getNotificationFrequency(notificationInterval);
+    // define how long to wait for each notification frequency
+    if (notificationFrequency == NotificationFrequency.UNDEFINED) {
+      notificationFrequency = NotificationFrequency.DAILY;
+    }
+
+    log.info("*************shintest:" + notificationFrequency.stringRepresentation);
 
     log.debug("searching for user by email " + requestParams);
 
@@ -59,7 +70,8 @@ public class NotificationController {
       return new ResponseEntity<String>(MSG, HttpStatus.NOT_FOUND);
     }
 
-    notificationService.subscribeUserNotification(user, notification);
+    notificationService.subscribeUserNotification(
+        user, notification, notificationFrequency.seconds);
 
     // Prepare return message
     Map<String, String> entity = new HashMap<>();
@@ -71,7 +83,7 @@ public class NotificationController {
   }
 
   /**
-   * Subscribes user to notifications
+   * Unsubscribes user to notifications
    *
    * @param requestParams
    * @return

--- a/src/main/java/edu/harvard/h2ms/web/controller/NotificationController.java
+++ b/src/main/java/edu/harvard/h2ms/web/controller/NotificationController.java
@@ -42,7 +42,7 @@ public class NotificationController {
     String email = (String) requestParams.get("email");
     String notificationName = (String) requestParams.get("notificationName");
     String notificationInterval = (String) requestParams.get("notificaitonInterval");
-    log.info("*************shintest:" + notificationInterval);
+
     NotificationFrequency notificationFrequency =
         NotificationFrequency.getNotificationFrequency(notificationInterval);
     // define how long to wait for each notification frequency
@@ -50,7 +50,6 @@ public class NotificationController {
       notificationFrequency = NotificationFrequency.DAILY;
     }
 
-    log.info("*************shintest:" + notificationFrequency.stringRepresentation);
 
     log.debug("searching for user by email " + requestParams);
 

--- a/src/test/java/edu/harvard/h2ms/controllers/NotificationControllerTests.java
+++ b/src/test/java/edu/harvard/h2ms/controllers/NotificationControllerTests.java
@@ -13,6 +13,7 @@ import edu.harvard.h2ms.domain.core.Notification;
 import edu.harvard.h2ms.domain.core.User;
 import edu.harvard.h2ms.repository.NotificationRepository;
 import edu.harvard.h2ms.repository.UserRepository;
+import edu.harvard.h2ms.service.utils.ReportUtils.NotificationFrequency;
 import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -130,6 +131,7 @@ public class NotificationControllerTests {
     ObjectNode objectNode2 = mapper2.createObjectNode();
     objectNode2.put("notificationName", NOTIFICATION_NAME);
     objectNode2.put("email", NOTIFICATION_EMAIL);
+    objectNode2.put("notificaitonInterval", NotificationFrequency.WEEKLY.stringRepresentation);
 
     MockHttpServletResponse result2 =
         mvc.perform(
@@ -155,6 +157,11 @@ public class NotificationControllerTests {
 
     // subscriber count should be 1 now.
     assertThat(notifiedUsers1.size(), is(1));
+
+    // test ability to set user-notification pair specific interval.
+    assertThat(
+        notification1.getEmailNotificationIntervals().get(NOTIFICATION_EMAIL),
+        is(NotificationFrequency.WEEKLY.seconds));
 
     // Subscribe 2nd user
 


### PR DESCRIPTION
### Please give a short summary of what's included in this submission

Added ability for user to subscribe to notification with its own interval (e.g., user1 can subscribe to daily and weekly notification at once).  Use json post field "notificationInterval" to value like DAILY or WEEKLY). Test included.

### Checklist
- [x] The Pull Request title describes the changes I've made
- [x] I've reviewed the **Files changed** tab
- [x] The code in the **Files changed** tab meets our style guides
- [x] New classes and public methods in the **Files changed** tab are documented
- [x] I've added two reviewers for this pull request


### Frontend Reviewer Checklist
##### I've reviewed the observe page, reports page, and any page directly affected by these changes
- [ ] For Mobile (width: ~320px) [View](http://whatismyscreenresolution.net/multi-screen-test?site-url=http://localhost:4200/login&w=320&h=480)
- [ ] For Tablet landscape (width: ~1024px) [View](http://whatismyscreenresolution.net/multi-screen-test?site-url=http://localhost:4200/login&w=1024&h=768)
- [ ] For Desktop (width: 1920px) [View](http://whatismyscreenresolution.net/multi-screen-test?site-url=http://localhost:4200/login&w=1920&h=1080)
- [ ] I've reviewed the **Files Changed** Tab and left constructive criticism (if applicable)

###### Optional
- [ ] For Tablet portrait (width: ~768px) [View](http://whatismyscreenresolution.net/multi-screen-test?site-url=http://localhost:4200/login&w=768&h=1024)