### PR TITLE
Actually return a sign-up URL

### DIFF
--- a/src/main/java/edu/harvard/h2ms/repository/EventRepository.java
+++ b/src/main/java/edu/harvard/h2ms/repository/EventRepository.java
@@ -12,7 +12,9 @@ public interface EventRepository extends PagingAndSortingRepository<Event, Long>
   List<Event> findByEventTemplate(@Param("eventTemplate") EventTemplate eventTemplate);
 
   List<Event> findByEventTemplateAndTimestampAfterAndTimestampBefore(
-		  @Param("eventTemplate") EventTemplate eventTemplate, @Param("after") Date after, @Param("before") Date before);
+      @Param("eventTemplate") EventTemplate eventTemplate,
+      @Param("after") Date after,
+      @Param("before") Date before);
 
   Long countByObserver(@Param("observer") User observer);
 }

--- a/src/main/java/edu/harvard/h2ms/seeders/RoleSeeder.java
+++ b/src/main/java/edu/harvard/h2ms/seeders/RoleSeeder.java
@@ -26,10 +26,10 @@ public class RoleSeeder {
   }
 
   private void seedRoleTable() {
-    if (roleRepository.count() == 0) {
-      List<String> records = asList("ROLE_ADMIN", "ROLE_USER", "ROLE_OBSERVER");
+    List<String> records = asList("ROLE_ADMIN", "ROLE_USER", "ROLE_OBSERVER");
 
-      for (String record : records) {
+    for (String record : records) {
+      if (roleRepository.findByName(record) == null) {
         Role role = new Role();
         role.setName(record);
         roleRepository.save(role);


### PR DESCRIPTION

### Please give a short summary of what's included in this submission

Currently the sign-up e-mail just sends a token.  The frontend doesn't
give us a callback URL for sign-up like it does for password reset.  This is
a little bit hacky to look at the referer, but it works and we'll
generate the correct URL based on a Referer sent from the browser.

This gives a user something to click.

### Checklist
- [X] The Pull Request title describes the changes I've made
- [X] I've reviewed the **Files changed** tab
- [X] The code in the **Files changed** tab meets our style guides
- [X] New classes and public methods in the **Files changed** tab are documented
- [X] I've added two reviewers for this pull request
