### PR TITLE
Bug Fix: Incorrect Observer Submitted with Event

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -19,7 +19,6 @@ import {AdminGuardService} from './auth/guards/admin-guard.service';
 import {UserComponent} from './user/user.component';
 import {RoleResolverService} from './role/service/role-resolver.service';
 import {ErrorComponent} from './error/error.component';
-import {UsersByEmailResolverService} from './user/service/users-by-email-resolver.service';
 import {ErrorGuardService} from './error/error-guard.service';
 import {LocationEditComponent} from './location-edit/location-edit.component';
 import {LocationComponent} from './location/location.component';
@@ -40,7 +39,7 @@ const routes: Routes = [
             locationResolver: LocationResolverService,
             usersResolver: UsersResolverService,
             questionResolver: QuestionResolverService,
-            userByEmailResolver: UsersByEmailResolverService
+            userByEmailResolver: UserByEmailResolverService
         }
     },
     {

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -62,7 +62,7 @@ import {EventGuardService} from './auth/guards/event-guard.service';
 import {AdminGuardService} from './auth/guards/admin-guard.service';
 import {UserRoleService} from './user/service/user-role.service';
 import {UserRegistrationService} from './api/registration.service';
-import {UsersByEmailResolverService} from './user/service/users-by-email-resolver.service';
+import {UserByEmailResolverService} from './user/service/user-by-email-resolver.service';
 import {ErrorComponent} from './error/error.component';
 import {UserRoleCheckService} from './user/service/user-role-check.service';
 import {ErrorService} from './error/error.service';
@@ -153,7 +153,7 @@ import {LocationEditComponent} from './location-edit/location-edit.component';
         UserRegistrationService,
         RoleEntityService,
         UserRoleCheckService,
-        UsersByEmailResolverService,
+        UserByEmailResolverService,
         ErrorService,
         ParentLocationFinder,
         LoggedInUserService

--- a/frontend/src/app/dynamic-form/dynamic-form.component.ts
+++ b/frontend/src/app/dynamic-form/dynamic-form.component.ts
@@ -30,7 +30,7 @@ export class DynamicFormComponent implements OnInit {
                 private eventEntityService: EventEntityService,
                 public dialog: MatDialog,
                 private actr: ActivatedRoute,
-                @Optional()@Inject(BASE_PATH) basePath: string,
+                @Optional() @Inject(BASE_PATH) basePath: string,
                 @Optional() configuration: Configuration,
                 @Optional() configService: ConfigService) {
         if (basePath) {
@@ -49,7 +49,7 @@ export class DynamicFormComponent implements OnInit {
 
     ngOnInit() {
         this.form = this.questionControlService.toFormGroup(this.questions);
-        this.loggedInUser = this.actr.snapshot.data.userByEmailResolver._embedded.users[0];
+        this.loggedInUser = this.actr.snapshot.data.userByEmailResolver;
     }
 
     onSubmit() {

--- a/frontend/src/app/user/service/user-role.service.ts
+++ b/frontend/src/app/user/service/user-role.service.ts
@@ -1,29 +1,26 @@
 import {Injectable} from '@angular/core';
-import {UsersByEmailResolverService} from './users-by-email-resolver.service';
+import {UserByEmailResolverService} from './user-by-email-resolver.service';
 import {Observable} from 'rxjs/Observable';
 import {UserEmailService} from './user-email.service';
 
 @Injectable()
 export class UserRoleService {
 
-    constructor(private usersByEmailResolverService: UsersByEmailResolverService,
-                private userEmailService: UserEmailService) { }
+    constructor(private userByEmailResolverService: UserByEmailResolverService,
+                private userEmailService: UserEmailService) {
+    }
 
     /**
      * determine if the current user has any role in list
      */
     hasRoles(list: [string]): Observable<boolean> {
         const email = this.userEmailService.getEmail();
-        return this.usersByEmailResolverService.resolve().flatMap((response) => {
-            const users = response._embedded.users;
+        return this.userByEmailResolverService.resolve().flatMap((user) => {
+            console.log(user);
             let hasARoleFromList = false;
-            users.forEach(user => {
-                if (email.match(user.email)) {
-                    const roles = user.authorities.map(role => role.authority);
-                    list.forEach(role => {
-                        hasARoleFromList = hasARoleFromList || roles.includes(role);
-                    });
-                }
+            const roles = user.authorities.map(role => role.authority);
+            list.forEach(role => {
+                hasARoleFromList = hasARoleFromList || roles.includes(role);
             });
             return Observable.of(hasARoleFromList);
         });

--- a/frontend/src/app/user/service/user-role.service.ts
+++ b/frontend/src/app/user/service/user-role.service.ts
@@ -16,7 +16,6 @@ export class UserRoleService {
     hasRoles(list: [string]): Observable<boolean> {
         const email = this.userEmailService.getEmail();
         return this.userByEmailResolverService.resolve().flatMap((user) => {
-            console.log(user);
             let hasARoleFromList = false;
             const roles = user.authorities.map(role => role.authority);
             list.forEach(role => {

--- a/frontend/src/app/user/service/user-role.service.ts
+++ b/frontend/src/app/user/service/user-role.service.ts
@@ -17,7 +17,7 @@ export class UserRoleService {
         const email = this.userEmailService.getEmail();
         return this.userByEmailResolverService.resolve().flatMap((user) => {
             const roles = user.authorities.map(role => role.authority);
-            let hasARoleFromList = list.some(role => roles.includes(role));
+            const hasARoleFromList = list.some(role => roles.includes(role));
             return Observable.of(hasARoleFromList);
         });
     }

--- a/frontend/src/app/user/service/user-role.service.ts
+++ b/frontend/src/app/user/service/user-role.service.ts
@@ -16,11 +16,8 @@ export class UserRoleService {
     hasRoles(list: [string]): Observable<boolean> {
         const email = this.userEmailService.getEmail();
         return this.userByEmailResolverService.resolve().flatMap((user) => {
-            let hasARoleFromList = false;
             const roles = user.authorities.map(role => role.authority);
-            list.forEach(role => {
-                hasARoleFromList = hasARoleFromList || roles.includes(role);
-            });
+            let hasARoleFromList = list.some(role => roles.includes(role));
             return Observable.of(hasARoleFromList);
         });
     }


### PR DESCRIPTION
### Please give a short summary of what's included in this submission
There was a bug in the event form that would make sure that anytime an event was submitted, the observer would always be the admin. I'm fixing that bug here.

You can easily test my changes on the live site, by submitting with a lesser used account, then checking the reports page.

### Checklist
- [x] The Pull Request title describes the changes I've made
- [x] I've reviewed the **Files changed** tab
- [x] The code in the **Files changed** tab meets our style guides
- [x] New classes and public methods in the **Files changed** tab are documented
- [x] I've added two reviewers for this pull request


### Frontend Reviewer Checklist
##### I've reviewed the observe page, reports page, and any page directly affected by these changes
- [x] For Mobile (width: ~320px) [View](http://whatismyscreenresolution.net/multi-screen-test?site-url=http://localhost:4200/login&w=320&h=480)
- [x] For Tablet landscape (width: ~1024px) [View](http://whatismyscreenresolution.net/multi-screen-test?site-url=http://localhost:4200/login&w=1024&h=768)
- [x] For Desktop (width: 1920px) [View](http://whatismyscreenresolution.net/multi-screen-test?site-url=http://localhost:4200/login&w=1920&h=1080)
- [x] I've reviewed the **Files Changed** Tab and left constructive criticism (if applicable)

###### Optional
- [ ] For Tablet portrait (width: ~768px) [View](http://whatismyscreenresolution.net/multi-screen-test?site-url=http://localhost:4200/login&w=768&h=1024)